### PR TITLE
Checks for null property values

### DIFF
--- a/SlackReactor.cs
+++ b/SlackReactor.cs
@@ -161,6 +161,7 @@ namespace Seq.Slack
                 {
                     if (SpecialProperties.Contains(property.Key)) continue;
                     if (property.Key == "StackTrace") continue;
+                    if (property.Value == null) continue;
 
                     otherProperties.fields.Add(new { value = property.Value.ToString(), title = property.Key, @short = false });
                 }


### PR DESCRIPTION
Was having an issue when using the app to send alerts from the dashboard, found that a Property `Errors` had a null value which caused the reactor to throw.

If a property does not have a value, making it fairly useless, it is excluded.

Might be worth adding `AlertId`, `DashboardId`, `SignalIds`, etc to the list of `SpecialProperties` or dealing with alerts as a whole other thing. Happy to discuss.