### PR TITLE
Support Seq Alerts, including dashboard link and results links.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ Downloaded Profiling Logs/*
 *.Sync*
 *.ide/
 *.nupkg
+/.vs

--- a/Seq.App.Slack.csproj
+++ b/Seq.App.Slack.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{80C336AB-5408-45E5-9D41-850CDF0DAD46}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Seq.Slack</RootNamespace>
-    <AssemblyName>Seq.Slack</AssemblyName>
+    <RootNamespace>Seq.App.Slack</RootNamespace>
+    <AssemblyName>Seq.App.Slack</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
@@ -32,21 +32,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Seq.Apps, Version=1.6.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>packages\Seq.Apps.1.6.4\lib\net45\Seq.Apps.dll</HintPath>
+    <Reference Include="Seq.Apps, Version=3.4.17.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Seq.Apps.3.4.17\lib\net45\Seq.Apps.dll</HintPath>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>packages\Serilog.2.5.0\lib\net45\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable">
@@ -70,12 +63,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SlackMessage.cs" />
     <Compile Include="SlackReactor.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
-    <None Include="Seq.Slack.nuspec" />
+    <None Include="Seq.App.Slack.nuspec" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/Seq.App.Slack.nuspec
+++ b/Seq.App.Slack.nuspec
@@ -1,14 +1,14 @@
 ﻿<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Seq.App.Slack</id>
-    <version>0.1.8</version>
+    <version>0.2.0</version>
     <authors>bytenik</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>An app for Seq (http://getseq.net) that forwards messages to Slack.</description>
+    <description>An app for Seq (https://getseq.net) that forwards messages to Slack.</description>
     <language>en-US</language>
     <projectUrl>https://github.com/bytenik/Seq.App.Slack</projectUrl>
-    <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
-    <iconUrl>http://cdn.appstorm.net/web.appstorm.net/web/files/2013/10/slack_icon.png</iconUrl>
+    <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
+    <iconUrl>https://cdn.appstorm.net/web.appstorm.net/web/files/2013/10/slack_icon.png</iconUrl>
     <tags>seq-app seq serilog events Slack</tags>
   </metadata>
   <files>

--- a/Seq.App.Slack.sln
+++ b/Seq.App.Slack.sln
@@ -1,9 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30501.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27004.2008
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Seq.Slack", "Seq.Slack.csproj", "{80C336AB-5408-45E5-9D41-850CDF0DAD46}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Seq.App.Slack", "Seq.App.Slack.csproj", "{80C336AB-5408-45E5-9D41-850CDF0DAD46}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{225F20AD-89E9-45F9-9249-ECB09E31A885}"
+	ProjectSection(SolutionItems) = preProject
+		appveyor.yml = appveyor.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,5 +23,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E61C3387-2CD9-45BB-A043-CD71994AE12F}
 	EndGlobalSection
 EndGlobal

--- a/SlackMessage.cs
+++ b/SlackMessage.cs
@@ -1,0 +1,13 @@
+﻿namespace Seq.App.Slack
+{
+    static class SlackMessage
+    {
+        public static string Escape(string s)
+        {
+            return s
+                .Replace("<", "&lt;")
+                .Replace(">", "&gt;")
+                .Replace("&", "&amp;");
+        }
+    }
+}

--- a/SlackReactor.cs
+++ b/SlackReactor.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Seq.Apps;
 using Seq.Apps.LogEvents;
 using System;
@@ -11,20 +10,15 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
-namespace Seq.Slack
+namespace Seq.App.Slack
 {
     [SeqApp("Slack Notifier", Description = "Sends messages matching a view to Slack.")]
     public class SlackReactor : Reactor, ISubscribeTo<LogEventData>
     {
         private static readonly Regex PlaceholdersRegex = new Regex("(\\[(?<key>[^\\[\\]]+?)(\\:(?<format>[^\\[\\]]+?))?\\])", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+        private const uint AlertEventType = 0xA1E77000;
 
-        [SeqAppSetting(
-            DisplayName = "Seq Base URL",
-            HelpText = "Used for generating perma links to events in Slack messages.",
-        IsOptional = true)]
-        public string BaseUrl { get; set; }
         [SeqAppSetting(
             DisplayName = "Webhook URL",
             HelpText = "Slack labels this as \"Your Unique Webhook URL\".")]
@@ -37,10 +31,16 @@ namespace Seq.Slack
         public string Channel { get; set; }
 
         [SeqAppSetting(
-            DisplayName = "Username",
+            DisplayName = "App name",
             IsOptional = true,
-            HelpText = "The username that Seq uses when posting to Slack. If not specified, uses the Webhook default. Username can also be a PropertyKey in the format [PropertyKey].")]
+            HelpText = "The name that Seq uses when posting to Slack. If not specified, uses the Webhook default. The name can also be read from a property by using the format [PropertyName].")]
         public string Username { get; set; }
+
+        [SeqAppSetting(
+            DisplayName = "Seq base URL",
+            HelpText = "Used for generating links to events in Slack messages. The default is the value supplied by Seq.",
+            IsOptional = true)]
+        public string BaseUrl { get; set; }
 
         [SeqAppSetting(
             DisplayName = "Suppression time (minutes)",
@@ -49,17 +49,19 @@ namespace Seq.Slack
         public int SuppressionMinutes { get; set; } = 0;
 
         [SeqAppSetting(
-            DisplayName = "Exclude Properties",
+            DisplayName = "Exclude properties",
             IsOptional = true,
-            HelpText = "Should the event include the property information as attachments to the message. The default is to include")]
+            HelpText = "Should the event include the property information as attachments to the message. The default is to attach all properties.")]
         public bool ExcludePropertyInformation { get; set; }
 
         [SeqAppSetting(
-            HelpText = "The message template to use when writing the message to Slack. Refer to https://api.slack.com/docs/formatting for formatting options. Event property values can be added in the format [PropertyKey]. The default is \"[RenderedMessage]\"",
+            DisplayName = "Message",
+            HelpText = "The message to send to Slack. Refer to https://api.slack.com/docs/formatting for formatting options. Event property values can be added in the format [PropertyName]. The default is \"[RenderedMessage]\". Ignored for Seq Alerts.",
             IsOptional = true)]
         public string MessageTemplate { get; set; }
 
         [SeqAppSetting(
+            DisplayName = "Icon URL",
             HelpText = "The image to show in the room for the message. The default is https://getseq.net/images/nuget/seq.png",
             IsOptional = true)]
         public string IconUrl { get; set; }
@@ -111,13 +113,28 @@ namespace Seq.Slack
                 return;
             }
 
+            if (IsAlert(evt))
+            {
+                var resultsUrl = SafeGetProperty(evt, "ResultsUrl");
+                var resultsText = $"<{resultsUrl}|Explore detected results in Seq>";
+                var results = new
+                {
+                    color,
+                    text = resultsText
+                };
+                message.attachments.Add(results);
+
+                SendMessageToSlack(message);
+                return;
+            }
+
             var special = new
             {
                 color = color,
                 fields = new ArrayList { new { value = Enum.GetName(typeof(LogEventLevel), evt.Data.Level), title = "Level", @short = true } }
             };
-
             message.attachments.Add(special);
+
             foreach (var key in SpecialProperties)
             {
                 if (evt.Data.Properties == null || !evt.Data.Properties.ContainsKey(key)) continue;
@@ -174,13 +191,34 @@ namespace Seq.Slack
 
         private string GenerateMessageText(Event<LogEventData> evt)
         {
-            if (string.IsNullOrWhiteSpace(MessageTemplate))
-                MessageTemplate = "[RenderedMessage]";
-
-            var messageTemplateToUse = MessageTemplate;
-
             var seqUrl = string.IsNullOrWhiteSpace(BaseUrl) ? Host.ListenUris.FirstOrDefault() : BaseUrl;
-            return $"{SubstitutePlaceholders(messageTemplateToUse, evt)} (<{seqUrl}/#/events?filter=@Id%20%3D%3D%20%22{evt.Id}%22&show=expanded|View on Seq>)";
+
+            if (IsAlert(evt))
+            {
+                var dashboardUrl = SafeGetProperty(evt, "DashboardUrl");
+                var condition = SafeGetProperty(evt, "Condition", raw: true);
+                var dashboardTitle = SafeGetProperty(evt, "DashboardTitle");
+                var chartTitle = SafeGetProperty(evt, "ChartTitle");
+                return $"Alert condition `{condition}` detected on <{dashboardUrl}|{dashboardTitle}/{chartTitle}>.";
+            }
+
+            var messageTemplateToUse = string.IsNullOrWhiteSpace(MessageTemplate) ? "[RenderedMessage]" : MessageTemplate;
+            return $"{SubstitutePlaceholders(messageTemplateToUse, evt)} (<{seqUrl}/#/events?filter=@Id%20%3D%3D%20%22{evt.Id}%22&show=expanded|View this event in Seq>)";
+        }
+
+        private static bool IsAlert(Event<LogEventData> evt)
+        {
+            return evt.EventType == AlertEventType;
+        }
+
+        private static string SafeGetProperty(Event<LogEventData> evt, string propertyName, bool raw = false)
+        {
+            if (evt.Data.Properties.TryGetValue(propertyName, out var value))
+            {
+                if (value == null) return "`null`";
+                return raw ? value.ToString() : SlackMessage.Escape(value.ToString());
+            }
+            return "";
         }
 
         private void SendMessageToSlack(object message)
@@ -217,7 +255,7 @@ namespace Seq.Slack
 
         private string FormatValue(object value, string format)
         {
-            var rawValue = value?.ToString() ?? "(Null)";
+            var rawValue = value?.ToString() ?? "`null`";
 
             if (string.IsNullOrWhiteSpace(format))
                 return rawValue;
@@ -228,7 +266,7 @@ namespace Seq.Slack
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Could not format Slack message: {value} {format}", value, format);
+                Log.Error(ex, "Could not format Slack message: {Value} {Format}", value, format);
             }
 
             return rawValue;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
-version: 0.1.{build}
+version: 0.2.{build}
+image: Visual Studio 2017
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,14 +10,14 @@ before_build:
 - cmd: nuget restore
 
 build:
-  project: Seq.Slack.csproj
+  project: Seq.App.Slack.csproj
   verbosity: minimal
  
 after_build:
-- cmd: nuget pack Seq.Slack.csproj -version "%APPVEYOR_BUILD_VERSION%"
+- cmd: nuget pack Seq.App.Slack.csproj -version "%APPVEYOR_BUILD_VERSION%"
 
 artifacts:
-- path: '*.nupkg'
+- path: 'Seq.App.Slack.*.nupkg'
   name: nuget-package
   
 deploy:

--- a/packages.config
+++ b/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Bcl.Immutable" version="1.0.34" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="Seq.Apps" version="1.6.4" targetFramework="net45" />
-  <package id="Serilog" version="1.5.14" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Seq.Apps" version="3.4.17" targetFramework="net45" />
+  <package id="Serilog" version="2.5.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Resolves #18 

![image](https://user-images.githubusercontent.com/342712/32641775-88808c7c-c61b-11e7-8a94-0425881f8b63.png)

 * Handles alert events specifically, so that the dashboard and result set are linked, rather than the event
 * Brings package and namespace names into alignment
 * Reviewed field names/help text to line up with Seq UI conventions where I could
 * Package updates, to better match the ones that Seq will provide at runtime

No breaking changes, works on my Slack ;-) 