### PR TITLE
added support for proxy server and fixed bug #23 and #21

### DIFF
--- a/src/Seq.App.Slack/Properties/AssemblyInfo.cs
+++ b/src/Seq.App.Slack/Properties/AssemblyInfo.cs
@@ -6,9 +6,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("seq.app.slack")]
 [assembly: AssemblyDescription("An app for Seq (http://getseq.net) that forwards messages to Slack.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Datalust")]
+[assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("seq.app.slack")]
-[assembly: AssemblyCopyright("Copyright © Datalust 2018")]
+[assembly: AssemblyCopyright("Copyright © 2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/Seq.App.Slack/Properties/AssemblyInfo.cs
+++ b/src/Seq.App.Slack/Properties/AssemblyInfo.cs
@@ -12,6 +12,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("0.2.27")]
-[assembly: AssemblyFileVersion("0.2.27")]
-[assembly: AssemblyInformationalVersion("0.2.27")]
+[assembly: AssemblyVersion("0.2.28")]
+[assembly: AssemblyFileVersion("0.2.28")]
+[assembly: AssemblyInformationalVersion("0.2.28")]

--- a/src/Seq.App.Slack/Properties/AssemblyInfo.cs
+++ b/src/Seq.App.Slack/Properties/AssemblyInfo.cs
@@ -1,3 +1,17 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 [assembly: InternalsVisibleTo("Seq.App.Slack.Tests")]
+[assembly: AssemblyTitle("seq.app.slack")]
+[assembly: AssemblyDescription("An app for Seq (http://getseq.net) that forwards messages to Slack.")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Datalust")]
+[assembly: AssemblyProduct("seq.app.slack")]
+[assembly: AssemblyCopyright("Copyright © Datalust 2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: AssemblyVersion("0.2.27")]
+[assembly: AssemblyFileVersion("0.2.27")]
+[assembly: AssemblyInformationalVersion("0.2.27")]

--- a/src/Seq.App.Slack/Seq.App.Slack.nuspec
+++ b/src/Seq.App.Slack/Seq.App.Slack.nuspec
@@ -6,7 +6,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>An app for Seq (https://getseq.net) that forwards events to Slack.</description>
     <language>en-US</language>
-    <projectUrl>https://github.com/bytenik/Seq.App.Slack</projectUrl>
+    <projectUrl>https://github.com/rocklan/Seq.App.Slack</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <iconUrl>https://cdn.appstorm.net/web.appstorm.net/web/files/2013/10/slack_icon.png</iconUrl>
     <tags>seq-app seq serilog events Slack</tags>

--- a/src/Seq.App.Slack/Seq.App.Slack.nuspec
+++ b/src/Seq.App.Slack/Seq.App.Slack.nuspec
@@ -6,7 +6,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>An app for Seq (https://getseq.net) that forwards events to Slack.</description>
     <language>en-US</language>
-    <projectUrl>https://github.com/rocklan/Seq.App.Slack</projectUrl>
+    <projectUrl>https://github.com/bytenik/Seq.App.Slack</projectUrl>
     <licenseUrl>https://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <iconUrl>https://cdn.appstorm.net/web.appstorm.net/web/files/2013/10/slack_icon.png</iconUrl>
     <tags>seq-app seq serilog events Slack</tags>

--- a/src/Seq.App.Slack/SlackApi.cs
+++ b/src/Seq.App.Slack/SlackApi.cs
@@ -1,24 +1,48 @@
-﻿using System.Net.Http;
+﻿using System.Net;
+using System.Net.Http;
 using System.Text;
 using Newtonsoft.Json;
 
 namespace Seq.App.Slack
 {
-    static class SlackApi
+    class SlackApi
     {
-        private static readonly HttpClient HttpClient = new HttpClient();
+        private HttpClient httpClient;
 
-        private static readonly JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings
+        public SlackApi(string proxyServer)
         {
-            NullValueHandling = NullValueHandling.Ignore
-        };
+            if (!string.IsNullOrWhiteSpace(proxyServer))
+            {
+                WebProxy proxy = new WebProxy(proxyServer, false)
+                {
+                    UseDefaultCredentials = true
+                };
+                var httpClientHandler = new HttpClientHandler()
+                {
+                    Proxy = proxy,
+                    PreAuthenticate = true,
+                    UseDefaultCredentials = true,
+                };
+                httpClient = new HttpClient(handler: httpClientHandler);
+            }
+            else
+            {
+                httpClient = new HttpClient();
+            }
+        }
+
         
-        public static void SendMessage(string webhookUrl, SlackMessage message)
+        
+        public void SendMessage(string webhookUrl, SlackMessage message)
         {
-            var json = JsonConvert.SerializeObject(message, JsonSerializerSettings);
+            var settings = new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore
+            };
+            var json = JsonConvert.SerializeObject(message, settings);
             using (var content = new StringContent(json, Encoding.UTF8, "application/json"))
             {
-                var resp = HttpClient.PostAsync(webhookUrl, content).Result;
+                var resp = httpClient.PostAsync(webhookUrl, content).Result;
                 resp.EnsureSuccessStatusCode();
             }
         }

--- a/src/Seq.App.Slack/SlackApi.cs
+++ b/src/Seq.App.Slack/SlackApi.cs
@@ -7,7 +7,11 @@ namespace Seq.App.Slack
 {
     class SlackApi
     {
-        private HttpClient httpClient;
+        private readonly HttpClient _httpClient;
+        private static readonly JsonSerializerSettings _jsonSettings = new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore
+        };
 
         public SlackApi(string proxyServer)
         {
@@ -23,11 +27,11 @@ namespace Seq.App.Slack
                     PreAuthenticate = true,
                     UseDefaultCredentials = true,
                 };
-                httpClient = new HttpClient(handler: httpClientHandler);
+                _httpClient = new HttpClient(handler: httpClientHandler);
             }
             else
             {
-                httpClient = new HttpClient();
+                _httpClient = new HttpClient();
             }
         }
 
@@ -35,14 +39,10 @@ namespace Seq.App.Slack
         
         public void SendMessage(string webhookUrl, SlackMessage message)
         {
-            var settings = new JsonSerializerSettings
-            {
-                NullValueHandling = NullValueHandling.Ignore
-            };
-            var json = JsonConvert.SerializeObject(message, settings);
+            var json = JsonConvert.SerializeObject(message, _jsonSettings);
             using (var content = new StringContent(json, Encoding.UTF8, "application/json"))
             {
-                var resp = httpClient.PostAsync(webhookUrl, content).Result;
+                var resp = _httpClient.PostAsync(webhookUrl, content).Result;
                 resp.EnsureSuccessStatusCode();
             }
         }

--- a/src/Seq.App.Slack/SlackReactor.cs
+++ b/src/Seq.App.Slack/SlackReactor.cs
@@ -185,7 +185,7 @@ namespace Seq.App.Slack
 
         private string GenerateMessageText(Event<LogEventData> evt)
         {
-            var seqUrl = string.IsNullOrWhiteSpace(BaseUrl) ? Host.ListenUris.FirstOrDefault() : BaseUrl;
+            var seqUrl = Host.ListenUris.FirstOrDefault();
 
             if (IsAlert(evt))
             {

--- a/src/Seq.App.Slack/SlackReactor.cs
+++ b/src/Seq.App.Slack/SlackReactor.cs
@@ -32,12 +32,6 @@ namespace Seq.App.Slack
         public string Username { get; set; }
 
         [SeqAppSetting(
-            DisplayName = "Seq base URL",
-            HelpText = "Used for generating links to events in Slack messages. The default is the value supplied by Seq.",
-            IsOptional = true)]
-        public string BaseUrl { get; set; }
-
-        [SeqAppSetting(
             DisplayName = "Suppression time (minutes)",
             IsOptional = true,
             HelpText = "Once an event type has been sent to Slack, the time to wait before sending again. The default is zero.")]

--- a/test/Seq.App.Slack.Tests/PropertyFormatterTests.cs
+++ b/test/Seq.App.Slack.Tests/PropertyFormatterTests.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace Seq.App.Slack.Tests
+{
+    public class PropertyFormatterTests
+    {
+        SlackReactor slackReactor = new SlackReactor();
+
+        [Fact]
+        public void IntPropertyFormattedOk()
+        {
+            var result = slackReactor.convertPropertyValueToString(1);
+            Assert.Equal("1", result);
+        }
+
+        [Fact]
+        public void NullPropertyFormattedOk()
+        {
+            var result = slackReactor.convertPropertyValueToString(null);
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void DictionaryPropertiesSerialisedAsJson()
+        {
+            Dictionary<string, string> d = new Dictionary<string, string>();
+            d.Add("test", "value");
+            d.Add("test2", "value2");
+            var result = slackReactor.convertPropertyValueToString(d);
+            var expected = "{\"test\":\"value\",\"test2\":\"value2\"}";
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void DictionaryPropertiesSerialisedAsJsonShouldTruncate()
+        {
+            slackReactor.JsonTrunateAt = 5;
+
+            Dictionary<string, string> d = new Dictionary<string, string>();
+            d.Add("test", "value");
+            var result = slackReactor.convertPropertyValueToString(d);
+            var expected = "{\"tes...";
+            Assert.Equal(expected, result);
+        }
+
+    }
+
+}

--- a/test/Seq.App.Slack.Tests/PropertyFormatterTests.cs
+++ b/test/Seq.App.Slack.Tests/PropertyFormatterTests.cs
@@ -10,14 +10,14 @@ namespace Seq.App.Slack.Tests
         [Fact]
         public void IntPropertyFormattedOk()
         {
-            var result = slackReactor.convertPropertyValueToString(1);
+            var result = slackReactor.ConvertPropertyValueToString(1);
             Assert.Equal("1", result);
         }
 
         [Fact]
         public void NullPropertyFormattedOk()
         {
-            var result = slackReactor.convertPropertyValueToString(null);
+            var result = slackReactor.ConvertPropertyValueToString(null);
             Assert.Equal(string.Empty, result);
         }
 
@@ -27,19 +27,19 @@ namespace Seq.App.Slack.Tests
             Dictionary<string, string> d = new Dictionary<string, string>();
             d.Add("test", "value");
             d.Add("test2", "value2");
-            var result = slackReactor.convertPropertyValueToString(d);
+            var result = slackReactor.ConvertPropertyValueToString(d);
             var expected = "{\"test\":\"value\",\"test2\":\"value2\"}";
             Assert.Equal(expected, result);
         }
 
         [Fact]
-        public void DictionaryPropertiesSerialisedAsJsonShouldTruncate()
+        public void PropertiesShouldTruncateIfDesired()
         {
-            slackReactor.JsonTrunateAt = 5;
+            slackReactor.MaxPropertyLength = 5;
 
             Dictionary<string, string> d = new Dictionary<string, string>();
             d.Add("test", "value");
-            var result = slackReactor.convertPropertyValueToString(d);
+            var result = slackReactor.ConvertPropertyValueToString(d);
             var expected = "{\"tes...";
             Assert.Equal(expected, result);
         }

--- a/test/Seq.App.Slack.Tests/Seq.App.Slack.Tests.csproj
+++ b/test/Seq.App.Slack.Tests/Seq.App.Slack.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Seq.Apps" Version="4.2.470" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/test/Seq.App.Slack.Tests/SlackSyntaxTests.cs
+++ b/test/Seq.App.Slack.Tests/SlackSyntaxTests.cs
@@ -10,5 +10,7 @@ namespace Seq.App.Slack.Tests
             var link = SlackSyntax.Hyperlink("http://example.com", "Hello, world!");
             Assert.Equal("<http://example.com|Hello, world!>", link);
         }
+
     }
+
 }


### PR DESCRIPTION
This pull request adds support for specifying a proxy server when making the request to Slack's API. It also fixes the bug where properties are not serialised as JSON. Added a few unit tests too and a few other misc things.