### PR TITLE
Allow users to configure the properties to include as fields when log…

### DIFF
--- a/src/Seq.App.Slack/ISlackApi.cs
+++ b/src/Seq.App.Slack/ISlackApi.cs
@@ -1,0 +1,7 @@
+﻿namespace Seq.App.Slack
+{
+    public interface ISlackApi
+    {
+        void SendMessage(string webhookUrl, SlackMessage message);
+    }
+}

--- a/src/Seq.App.Slack/Seq.App.Slack.csproj
+++ b/src/Seq.App.Slack/Seq.App.Slack.csproj
@@ -66,6 +66,7 @@
   <ItemGroup>
     <Compile Include="EventFormatting.cs" />
     <Compile Include="EventTypeSuppressions.cs" />
+    <Compile Include="ISlackApi.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SlackMessage.cs" />
     <Compile Include="SlackMessageAttachment.cs" />

--- a/src/Seq.App.Slack/SlackApi.cs
+++ b/src/Seq.App.Slack/SlackApi.cs
@@ -5,7 +5,12 @@ using Newtonsoft.Json;
 
 namespace Seq.App.Slack
 {
-    class SlackApi
+    public interface ISlackApi
+    {
+        void SendMessage(string webhookUrl, SlackMessage message);
+    }
+
+    class SlackApi : ISlackApi
     {
         private readonly HttpClient _httpClient;
         private static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings

--- a/src/Seq.App.Slack/SlackApi.cs
+++ b/src/Seq.App.Slack/SlackApi.cs
@@ -5,11 +5,6 @@ using Newtonsoft.Json;
 
 namespace Seq.App.Slack
 {
-    public interface ISlackApi
-    {
-        void SendMessage(string webhookUrl, SlackMessage message);
-    }
-
     class SlackApi : ISlackApi
     {
         private readonly HttpClient _httpClient;

--- a/src/Seq.App.Slack/SlackReactor.cs
+++ b/src/Seq.App.Slack/SlackReactor.cs
@@ -70,12 +70,12 @@ namespace Seq.App.Slack
         [SeqAppSetting(
             DisplayName = "Included properties",
             IsOptional = true,
-            HelpText = "Comma separated list (no spaces) of properties to include as attachments.  The default is to include all properties.")]
+            HelpText = "Comma separated list of properties to include as attachments.  The default is to include all properties.")]
         public string IncludedProperties { get; set; }
 
         private EventTypeSuppressions _suppressions;
         private static readonly IImmutableList<string> SpecialProperties = ImmutableList.Create("Id", "Host");
-        private static ISlackApi _slackApi;
+        private ISlackApi _slackApi;
         private static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings
         {
             NullValueHandling = NullValueHandling.Ignore
@@ -151,7 +151,7 @@ namespace Seq.App.Slack
                 message.Attachments.Add(new SlackMessageAttachment(color, SlackSyntax.Preformatted(stackTrace), "Stack Trace", textIsMarkdown: true));
             }
 
-            var includedPropertiesArray = string.IsNullOrWhiteSpace(IncludedProperties) ? new string[0] : IncludedProperties.Split(',');
+            var includedPropertiesArray = string.IsNullOrWhiteSpace(IncludedProperties) ? new string[0] : IncludedProperties.Split(',').Select(x => x.Trim());
             var otherProperties = new SlackMessageAttachment(color, "Properties");
             if (evt.Data.Properties != null)
             {

--- a/src/Seq.App.Slack/SlackReactor.cs
+++ b/src/Seq.App.Slack/SlackReactor.cs
@@ -67,13 +67,28 @@ namespace Seq.App.Slack
             HelpText = "If a property when converted to a string is longer than this number it will be truncated")]
         public int? MaxPropertyLength { get; set; } = null;
 
+        [SeqAppSetting(
+            DisplayName = "Included properties",
+            IsOptional = true,
+            HelpText = "Comma separated list (no spaces) of properties to include as attachments.  The default is to include all properties.")]
+        public string IncludedProperties { get; set; }
+
         private EventTypeSuppressions _suppressions;
         private static readonly IImmutableList<string> SpecialProperties = ImmutableList.Create("Id", "Host");
-        private static SlackApi _slackApi;
+        private static ISlackApi _slackApi;
         private static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings
         {
             NullValueHandling = NullValueHandling.Ignore
         };
+
+        public SlackReactor()
+        {
+        }
+
+        internal SlackReactor(ISlackApi slackApi)
+        {
+            _slackApi = slackApi;
+        }
 
         public void On(Event<LogEventData> evt)
         {
@@ -136,6 +151,7 @@ namespace Seq.App.Slack
                 message.Attachments.Add(new SlackMessageAttachment(color, SlackSyntax.Preformatted(stackTrace), "Stack Trace", textIsMarkdown: true));
             }
 
+            var includedPropertiesArray = string.IsNullOrWhiteSpace(IncludedProperties) ? new string[0] : IncludedProperties.Split(',');
             var otherProperties = new SlackMessageAttachment(color, "Properties");
             if (evt.Data.Properties != null)
             {
@@ -143,6 +159,7 @@ namespace Seq.App.Slack
                 {
                     if (SpecialProperties.Contains(property.Key)) continue;
                     if (property.Key == "StackTrace") continue;
+                    if (includedPropertiesArray.Any() && !includedPropertiesArray.Contains(property.Key)) continue;
 
                     string value = ConvertPropertyValueToString(property.Value);
                     

--- a/test/Seq.App.Slack.Tests/Seq.App.Slack.Tests.csproj
+++ b/test/Seq.App.Slack.Tests/Seq.App.Slack.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Seq.Apps" Version="4.2.470" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/test/Seq.App.Slack.Tests/SlackReactorTests.cs
+++ b/test/Seq.App.Slack.Tests/SlackReactorTests.cs
@@ -42,16 +42,30 @@ namespace Seq.App.Slack.Tests
         }
 
         [Fact]
-        public void GivenIncludedPropertiesAreSupplieThenTheyAreRespected()
+        public void GivenIncludedPropertiesAreSuppliedThenTheyAreRespected()
         {
-            _slackReactor.IncludedProperties = "Property1,Property3";             
+            _slackReactor.IncludedProperties = "  Property1,   Property2,  Property3  ";             
+
+            _slackReactor.On(_event);
+
+            // Ensure the message we send to slack only includes the properties specified
+            _slackApi.Received().SendMessage(_slackReactor.WebhookUrl, Arg.Is<SlackMessage>(x => x.Attachments.Single(a => a.Text == "Properties").Fields.Count == 3 &&
+                                                                                               x.Attachments.Single(a => a.Text == "Properties").Fields.Any(a => a.Title == "Property1") &&
+                                                                                               x.Attachments.Single(a => a.Text == "Properties").Fields.Any(a => a.Title == "Property2") &&
+                                                                                               x.Attachments.Single(a => a.Text == "Properties").Fields.Any(a => a.Title == "Property3")));
+        }
+
+        [Fact]
+        public void GivenIncludedPropertiesWithWhitespaceAreSuppliedThenTheyAreRespected()
+        {
+            _slackReactor.IncludedProperties = "Property1,Property3";
 
             _slackReactor.On(_event);
 
             // Ensure the message we send to slack only includes the properties specified
             _slackApi.Received().SendMessage(_slackReactor.WebhookUrl, Arg.Is<SlackMessage>(x => x.Attachments.Single(a => a.Text == "Properties").Fields.Count == 2 &&
-                                                                                               x.Attachments.Single(a => a.Text == "Properties").Fields.Any(a => a.Title == "Property1") &&
-                                                                                               x.Attachments.Single(a => a.Text == "Properties").Fields.Any(a => a.Title == "Property3")));
+                                                                                                 x.Attachments.Single(a => a.Text == "Properties").Fields.Any(a => a.Title == "Property1") &&
+                                                                                                 x.Attachments.Single(a => a.Text == "Properties").Fields.Any(a => a.Title == "Property3")));
         }
 
         [Fact]

--- a/test/Seq.App.Slack.Tests/SlackReactorTests.cs
+++ b/test/Seq.App.Slack.Tests/SlackReactorTests.cs
@@ -1,0 +1,81 @@
+﻿using NSubstitute;
+using Seq.Apps;
+using Seq.Apps.LogEvents;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Seq.App.Slack.Tests
+{
+    public class SlackReactorTests
+    {
+        private SlackReactor _slackReactor;
+        private ISlackApi _slackApi;
+        private IAppHost _appHost;
+        private Event<LogEventData> _event;
+
+        public SlackReactorTests()
+        {
+            _slackApi = Substitute.For<ISlackApi>();
+            _appHost = Substitute.For<IAppHost>();
+            _appHost.Host.Returns(new Host(new[] { "listenUri" }, "instance"));
+            _appHost.App.Returns(new Apps.App("app-id", "App Title", new Dictionary<string, string>(), "storage-path"));
+
+            _slackReactor = new SlackReactor(_slackApi)
+            {
+                WebhookUrl = "http://webhookurl.com"
+            };
+            _slackReactor.Attach(_appHost);
+
+            _event = new Event<LogEventData>("id", 1, DateTime.Now, new LogEventData
+            {
+                Id = "111",
+                Level = LogEventLevel.Information,
+                Properties = new Dictionary<string, object>()
+                {
+                    {"Property1", "Value1"},
+                    {"Property2", "Value2"},
+                    {"Property3", "Value3"}
+                }
+            });
+        }
+
+        [Fact]
+        public void GivenIncludedPropertiesAreSupplieThenTheyAreRespected()
+        {
+            _slackReactor.IncludedProperties = "Property1,Property3";             
+
+            _slackReactor.On(_event);
+
+            // Ensure the message we send to slack only includes the properties specified
+            _slackApi.Received().SendMessage(_slackReactor.WebhookUrl, Arg.Is<SlackMessage>(x => x.Attachments.Single(a => a.Text == "Properties").Fields.Count == 2 &&
+                                                                                               x.Attachments.Single(a => a.Text == "Properties").Fields.Any(a => a.Title == "Property1") &&
+                                                                                               x.Attachments.Single(a => a.Text == "Properties").Fields.Any(a => a.Title == "Property3")));
+        }
+
+        [Fact]
+        public void GivenIncludedPropertiesNotSetThenAllPropertiesAreIncluded()
+        {
+            _slackReactor.On(_event);
+
+            // Ensure the message we send to slack only includes the properties specified
+            _slackApi.Received().SendMessage(_slackReactor.WebhookUrl, Arg.Is<SlackMessage>(x => x.Attachments.Single(a => a.Text == "Properties").Fields.Count == 3 &&
+                                                                                               x.Attachments.Single(a => a.Text == "Properties").Fields.Any(a => a.Title == "Property1") &&
+                                                                                               x.Attachments.Single(a => a.Text == "Properties").Fields.Any(a => a.Title == "Property2") &&
+                                                                                               x.Attachments.Single(a => a.Text == "Properties").Fields.Any(a => a.Title == "Property3")));
+        }
+
+        [Fact]
+        public void GivenIncludedPropertiesContainsPropertiesThatDontExistThenTheyAreIgnored()
+        {
+            _slackReactor.IncludedProperties = "Property1,PropertyDoesntExist";              
+
+            _slackReactor.On(_event);
+
+            // Ensure the message we send to slack only includes the properties specified
+            _slackApi.Received().SendMessage(_slackReactor.WebhookUrl, Arg.Is<SlackMessage>(x => x.Attachments.Single(a => a.Text == "Properties").Fields.Count == 1 &&
+                                                                                               x.Attachments.Single(a => a.Text == "Properties").Fields.Any(a => a.Title == "Property1")));
+        }
+    }
+}

--- a/test/Seq.App.Slack.Tests/SlackReactorTests.cs
+++ b/test/Seq.App.Slack.Tests/SlackReactorTests.cs
@@ -42,21 +42,20 @@ namespace Seq.App.Slack.Tests
         }
 
         [Fact]
-        public void GivenIncludedPropertiesAreSuppliedThenTheyAreRespected()
+        public void GivenIncludedPropertiesWithWhitespaceAreSuppliedThenTheyAreRespected()
         {
-            _slackReactor.IncludedProperties = "  Property1,   Property2,  Property3  ";             
+            _slackReactor.IncludedProperties = "  Property1 ,   Property2  ";             
 
             _slackReactor.On(_event);
 
             // Ensure the message we send to slack only includes the properties specified
-            _slackApi.Received().SendMessage(_slackReactor.WebhookUrl, Arg.Is<SlackMessage>(x => x.Attachments.Single(a => a.Text == "Properties").Fields.Count == 3 &&
+            _slackApi.Received().SendMessage(_slackReactor.WebhookUrl, Arg.Is<SlackMessage>(x => x.Attachments.Single(a => a.Text == "Properties").Fields.Count == 2 &&
                                                                                                x.Attachments.Single(a => a.Text == "Properties").Fields.Any(a => a.Title == "Property1") &&
-                                                                                               x.Attachments.Single(a => a.Text == "Properties").Fields.Any(a => a.Title == "Property2") &&
-                                                                                               x.Attachments.Single(a => a.Text == "Properties").Fields.Any(a => a.Title == "Property3")));
+                                                                                               x.Attachments.Single(a => a.Text == "Properties").Fields.Any(a => a.Title == "Property2")));
         }
 
         [Fact]
-        public void GivenIncludedPropertiesWithWhitespaceAreSuppliedThenTheyAreRespected()
+        public void GivenIncludedPropertiesAreSuppliedThenTheyAreRespected()
         {
             _slackReactor.IncludedProperties = "Property1,Property3";
 


### PR DESCRIPTION
Allow users to configure the properties to include as fields when logging to Slack.  I have implemented the change almost exactly as Nick suggested in issue 16 (Example of how to set MessageTemplate).

In order to test my changes I had to create an additional internal constructor that allowed me to pass a mock instance of SlackApi.