### PR TITLE
Specify source parameter when publishing NUPKG

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,6 @@ jobs:
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev'
         shell: pwsh
         run: |
-          dotnet nuget push (get-item ./artifacts/*.nupkg).FullName --api-key="$env:NUGET_API_KEY"
+          dotnet nuget push (get-item ./artifacts/*.nupkg).FullName --api-key="$env:NUGET_API_KEY" -s https://api.nuget.org/v3/index.json
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
> Starting with NuGet 3.4.2, this is a mandatory parameter unless the NuGet config file specifies a DefaultPushSource value. 

https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-nuget-push