### PR TITLE
Added a link to the Seq documentation for Seq.App.Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ An app for [Seq](https://datalust.co/seq) that forwards messages to [Slack](http
  5. Configure the app instance, providing the webhook URL
 
 Consult the Seq documentation for further information about [installing Seq apps](https://docs.datalust.co/docs/installing-seq-apps).
+
+For more information see [Notifying with Slack ](https://docs.datalust.co/docs/slack-notifications).

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ An app for [Seq](https://datalust.co/seq) that forwards messages to [Slack](http
 
 Consult the Seq documentation for further information about [installing Seq apps](https://docs.datalust.co/docs/installing-seq-apps).
 
-For more information see [Notifying with Slack ](https://docs.datalust.co/docs/slack-notifications).
+For more information see [Notifying with Slack](https://docs.datalust.co/docs/slack-notifications).


### PR DESCRIPTION
[Some users](https://github.com/datalust/seq-tickets/issues/1513) have had difficulty configuring the Slack app side, so including a link to the full documentation. 