### PR TITLE
Run tests under .NET 6

### DIFF
--- a/test/Seq.App.Slack.Tests/Seq.App.Slack.Tests.csproj
+++ b/test/Seq.App.Slack.Tests/Seq.App.Slack.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
.NET 5 is no longer available on the build workers.