### PR TITLE
Added HostHeader setting for custom Host

### DIFF
--- a/src/Seq.App.Slack/Api/SlackApi.cs
+++ b/src/Seq.App.Slack/Api/SlackApi.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -20,7 +21,7 @@ namespace Seq.App.Slack.Api
             NullValueHandling = NullValueHandling.Ignore
         };
 
-        public SlackApi(string proxyServer)
+        public SlackApi(string proxyServer, string hostHeader)
         {
             if (!string.IsNullOrWhiteSpace(proxyServer))
             {
@@ -40,8 +41,11 @@ namespace Seq.App.Slack.Api
             {
                 _httpClient = new HttpClient();
             }
+
+            if (!string.IsNullOrWhiteSpace(hostHeader))
+                _httpClient.DefaultRequestHeaders.Host = new Uri(hostHeader).Host;
         }
-        
+
         public async Task SendMessageAsync(string webhookUrl, SlackMessage message)
         {
             var json = JsonConvert.SerializeObject(message, JsonSettings);

--- a/src/Seq.App.Slack/SlackApp.cs
+++ b/src/Seq.App.Slack/SlackApp.cs
@@ -67,6 +67,12 @@ namespace Seq.App.Slack
             HelpText = "Proxy server to be used when making HTTPS requests to the Slack API. Uses default credentials.",
             IsOptional = true)]
         public string ProxyServer { get; set; }
+        
+        [SeqAppSetting(
+            DisplayName = "Host Header",
+            HelpText = "If you use a TLS/SSL tunneling service like stunnel, you need to set the Host header.",
+            IsOptional = true)]
+        public string HostHeader { get; set; }
 
         [SeqAppSetting(
             DisplayName = "Maximum property length",
@@ -98,7 +104,7 @@ namespace Seq.App.Slack
         {
             if (_slackApi == null)
             {
-                _slackApi = new SlackApi(ProxyServer);
+                _slackApi = new SlackApi(ProxyServer, HostHeader);
             }
 
             var propertyValueFormatter = new PropertyValueFormatter(MaxPropertyLength);


### PR DESCRIPTION
With the latest SSL certificate update on 17 November 2023 for hooks.slack.com, you cannot send Slack alerts using legacy cipher suites anymore. For legacy servers that work around TLS/Cipher Suite issues using tunneling services (e.g. stunnel), you need to set the Host header for your HTTP requests (sending slack alerts) to work.